### PR TITLE
fix cross origin

### DIFF
--- a/src/main/java/com/rmarcello/note/controller/NoteController.java
+++ b/src/main/java/com/rmarcello/note/controller/NoteController.java
@@ -1,6 +1,7 @@
 package com.rmarcello.note.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,6 +15,7 @@ import com.rmarcello.note.service.NoteService;
 
 import java.util.List;
 
+@CrossOrigin(origins = "*", allowedHeaders = "*")
 @RestController
 @RequestMapping("/notes")
 public class NoteController {


### PR DESCRIPTION
This pull request introduces a small but important update to the `NoteController` class to enable Cross-Origin Resource Sharing (CORS). This change allows the `NoteController` to handle requests from different origins, which is essential for modern web applications that interact with APIs hosted on different domains.

* [`src/main/java/com/rmarcello/note/controller/NoteController.java`](diffhunk://#diff-d898e2e7406ede1881fc8704729df0ad5ae109f424e10a2648299ba691af13bbR4): Added `@CrossOrigin` annotation to the `NoteController` class to allow requests from any origin with any headers. [[1]](diffhunk://#diff-d898e2e7406ede1881fc8704729df0ad5ae109f424e10a2648299ba691af13bbR4) [[2]](diffhunk://#diff-d898e2e7406ede1881fc8704729df0ad5ae109f424e10a2648299ba691af13bbR18)